### PR TITLE
Don't lowercase hostmask when checking against admin list

### DIFF
--- a/scripts/bantracker.pl
+++ b/scripts/bantracker.pl
@@ -676,7 +676,7 @@ sub update_ban {
       return 'No such record.';
     }
     my $row=shift @results;
-    if (irclc($data[0]) eq ${$row}[4] || irclc($data[0]) =~ $heap{'settings'}{${$row}[3]}{'admins'}) {
+    if (irclc($data[0]) eq ${$row}[4] || $data[0] =~ $heap{'settings'}{${$row}[3]}{'admins'}) {
       my $i=${$row}[0];
       if ($newtime && $newreason) {
        $query=$heap{query}{update_time_reason};


### PR DESCRIPTION
Right now, the user's hostmask is lowercased according to RFC 1459 conventions before it is checked against the admins regex. This is undesirable because it means the regex needs to be explicitly written with that implementation detail in mind. The regex cannot simply be passed a case-insensitive flag because RFC casing also transforms []\ into {}|. As such, it is preferable to remove the requirement to know an eir implementation detail at the expense of requiring proper casing in the admins regex.

Before merging this, it would be prudent to check existing admin lists to see if any of them are impacted by this change and alert the admins of the appropriate channel(s).
