### PR TITLE
Get eir building on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ make
 make install
 ```
 
+To install on FreeBSD, you will need `g++` and `gmake`, so something like this:
+```
+# if not already available do the following:
+sudo pkg install gcc6 gmake
+git submodule init
+git submodule update
+autoconf
+./configure --prefix=SOMEWHERE
+CXX=g++6 gmake
+gmake install
+
+```
+
 Then go to SOMEWHERE/etc, and write eir.conf. There is an example config file
 installed.
 

--- a/src/build.mk
+++ b/src/build.mk
@@ -22,4 +22,8 @@ eir_SOURCES = bot.cpp \
 	    value.cpp \
 
 eir_LDFLAGS = -Wl,-export-dynamic -Wl,-rpath,$(LIBDIR)
-eir_LIBRARIES = -ldl paludis/util/paludisutil
+ifeq ($(shell uname),FreeBSD)
+    eir_LIBRARIES = paludis/util/paludisutil
+else
+    eir_LIBRARIES = -ldl paludis/util/paludisutil
+endif

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -10,6 +10,9 @@
 
 #include <unistd.h>
 #include <sys/socket.h>
+#ifdef __FreeBSD__
+#  include <netinet/in.h>
+#endif
 #include <sys/select.h>
 #include <sys/types.h>
 #include <sys/time.h>


### PR DESCRIPTION
There's very little needed to get this working on FreeBSD. You just need to have gmake, gcc, and an additional header for sockets. You can probably get it work with FreeBSD clang, but it means modernizing the code a bit.