### PR TITLE
Support setting bans for Months and years

### DIFF
--- a/doc/bantracker/operators-guide.txt
+++ b/doc/bantracker/operators-guide.txt
@@ -57,7 +57,7 @@ example: "~14d Trolling"
 TIME SPECIFICATION
 
 When adding a comment or using the btset command, times can be specified in 
-[y]ears, [w]eeks, [d]ays, [h]ours, [m]inutes, [s]econds or in any combination together.
+[y]ears, [M]onths, [w]eeks, [d]ays, [h]ours, [m]inutes, [s]econds or in any combination together.
 
 Examples:
 

--- a/doc/bantracker/operators-guide.txt
+++ b/doc/bantracker/operators-guide.txt
@@ -57,7 +57,7 @@ example: "~14d Trolling"
 TIME SPECIFICATION
 
 When adding a comment or using the btset command, times can be specified in 
-[w]eeks, [d]ays, [h]ours, [m]inutes, [s]econds or in any combination together.
+[y]ears, [w]eeks, [d]ays, [h]ours, [m]inutes, [s]econds or in any combination together.
 
 Examples:
 

--- a/scripts/bantracker.pl
+++ b/scripts/bantracker.pl
@@ -720,7 +720,7 @@ sub calc_time {
   # and return a time in seconds
   my $spec=shift @_;
   my $time=0;
-  while ($spec =~ /^~?(\d+)([dhmsw]?)/) {
+  while ($spec =~ /^~?(\d+)([dhmswy]?)/) {
     if ($2 eq 'm') {
       $time+=$1*60;
     } elsif ($2 eq 'h') {
@@ -729,6 +729,8 @@ sub calc_time {
       $time+=$1*86400;
     } elsif ($2 eq 'w') {
       $time+=$1*604800;
+    } elsif ($2 eq 'y') {
+      $time+=$1*31557600
     } elsif ($2 eq 's') {
       $time+=$1;
     } else {

--- a/scripts/bantracker.pl
+++ b/scripts/bantracker.pl
@@ -720,7 +720,7 @@ sub calc_time {
   # and return a time in seconds
   my $spec=shift @_;
   my $time=0;
-  while ($spec =~ /^~?(\d+)([dhmswy]?)/) {
+  while ($spec =~ /^~?(\d+)([dhmswMy]?)/) {
     if ($2 eq 'm') {
       $time+=$1*60;
     } elsif ($2 eq 'h') {
@@ -729,8 +729,10 @@ sub calc_time {
       $time+=$1*86400;
     } elsif ($2 eq 'w') {
       $time+=$1*604800;
+    } elsif ($2 eq 'M') {
+      $time+=$1*2629800;
     } elsif ($2 eq 'y') {
-      $time+=$1*31557600
+      $time+=$1*31557600;
     } elsif ($2 eq 's') {
       $time+=$1;
     } else {


### PR DESCRIPTION
We have had a couple of occassions where we needed to set long bans. This change makes eir's bantracker support setting bans for `M`onths or `y`ears.